### PR TITLE
Improve conditional required story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- If both `.required` and `.optional` are present, the last one to be called takes precedence
+
 ## [1.3.0] - 2019-05-24
 
 ### Changed

--- a/src/__tests__/any.test.ts
+++ b/src/__tests__/any.test.ts
@@ -1,51 +1,5 @@
 import ok from '../index';
 
-describe('any', () => {
-  describe('not optional by default', () => {
-    const customMsg = 'This field is required!!!';
-    const schema = ok.any().required(customMsg);
-
-    test('null', () => {
-      const result = schema.validate(null);
-      expect(result.valid).toBe(false);
-    });
-
-    test('undefined', () => {
-      const result = schema.validate(undefined);
-      expect(result.valid).toBe(false);
-    });
-
-    test('empty string', () => {
-      const result = schema.validate('');
-      expect(result.valid).toBe(false);
-    });
-
-    test('string', () => {
-      const result = schema.validate('woah');
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe('optional', () => {
-    const schema = ok.any().optional();
-
-    test('null', () => {
-      const result = schema.validate(null);
-      expect(result.valid).toBe(true);
-    });
-
-    test('undefined', () => {
-      const result = schema.validate(undefined);
-      expect(result.valid).toBe(true);
-    });
-
-    test('empty string', () => {
-      const result = schema.validate('');
-      expect(result.valid).toBe(true);
-    });
-  });
-});
-
 describe('messages', () => {
   const customParsingMsg = 'Must be a number!!!';
   const customRequiredMsg = 'Field is required!!!';

--- a/src/__tests__/optional.test.ts
+++ b/src/__tests__/optional.test.ts
@@ -99,7 +99,7 @@ describe('uses last', () => {
       expect(result.valid).toBe(false);
     });
 
-    test.only('not required', () => {
+    test('not required', () => {
       const result = schema.validate({ required: false, value: null });
       expect(result.valid).toBe(true);
     });

--- a/src/__tests__/optional.test.ts
+++ b/src/__tests__/optional.test.ts
@@ -1,0 +1,107 @@
+import ok from '../index';
+
+describe('not optional by default', () => {
+  const customMsg = 'This field is required!!!';
+  const schema = ok.any().required(customMsg);
+
+  test('null', () => {
+    const result = schema.validate(null);
+    expect(result.valid).toBe(false);
+  });
+
+  test('undefined', () => {
+    const result = schema.validate(undefined);
+    expect(result.valid).toBe(false);
+  });
+
+  test('empty string', () => {
+    const result = schema.validate('');
+    expect(result.valid).toBe(false);
+  });
+
+  test('string', () => {
+    const result = schema.validate('woah');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('optional', () => {
+  const schema = ok.any().optional();
+
+  test('null', () => {
+    const result = schema.validate(null);
+    expect(result.valid).toBe(true);
+  });
+
+  test('undefined', () => {
+    const result = schema.validate(undefined);
+    expect(result.valid).toBe(true);
+  });
+
+  test('empty string', () => {
+    const result = schema.validate('');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('uses last', () => {
+  test('required -> optional', () => {
+    const schema = ok
+      .any()
+      .required()
+      .optional();
+    const result = schema.validate(null);
+    expect(result.valid).toBe(true);
+  });
+
+  test('optional -> required', () => {
+    const schema = ok
+      .any()
+      .optional()
+      .required();
+    const result = schema.validate(null);
+    expect(result.valid).toBe(false);
+  });
+
+  test('optional -> required -> optional', () => {
+    const schema = ok
+      .any()
+      .optional()
+      .required()
+      .optional();
+    const result = schema.validate(null);
+    expect(result.valid).toBe(true);
+  });
+
+  test('required -> optional -> required', () => {
+    const schema = ok
+      .any()
+      .required()
+      .optional()
+      .required();
+    const result = schema.validate(null);
+    expect(result.valid).toBe(false);
+  });
+
+  describe('conditional', () => {
+    const schema = ok.object({
+      required: ok.boolean(),
+      value: ok
+        .any()
+        .optional()
+        .test((_, { parent }) =>
+          parent.required ? ok.any().required() : ok.any().optional()
+        ),
+    });
+
+    test('required', () => {
+      const result = schema.validate({ required: true, value: null });
+      expect(result.valid).toBe(false);
+    });
+
+    test.only('not required', () => {
+      const result = schema.validate({ required: false, value: null });
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/src/any.ts
+++ b/src/any.ts
@@ -176,6 +176,7 @@ class OKAny<Input = any, Parent = any, Root = any> {
    * @param msg Error message if field is empty (empty string, null, undefined)
    */
   public required(msg?: string) {
+    this.isOptional = false;
     if (msg) {
       this.requiredMessage = msg;
     }


### PR DESCRIPTION
If both `.required` and `.optional` are present, the last one to be called takes precedence